### PR TITLE
Feat: #29 예약시간을 현재시간 이전으로 선택할 경우 예외처리 삭제

### DIFF
--- a/src/main/java/com/sparta/parknav/booking/service/BookingService.java
+++ b/src/main/java/com/sparta/parknav/booking/service/BookingService.java
@@ -75,11 +75,6 @@ public class BookingService {
 
     public ApiResponseDto<BookingResponseDto> bookingPark(Long id, BookingInfoRequestDto requestDto, User user) {
 
-        // 선택한 시간이 현재 시간 이전인 경우 예외처리
-        if (LocalDateTime.now().compareTo(requestDto.getStartDate()) > 0) {
-            throw new CustomException(ErrorType.NOT_AVAILABLE_TIME);
-        }
-
         ParkInfo parkInfo = parkInfoRepository.findById(id).orElseThrow(
                 () -> new CustomException(ErrorType.NOT_FOUND_PARK)
         );


### PR DESCRIPTION
## 📕 예약시간을 현재시간 이전으로 선택할 경우 예외처리 삭제

## 📗 작업 내용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feat/#29-booking -> develop

### 변경 사항
- 현재시간대로 예약시간을 설정할 수 있으므로 기존 예외처리 삭제

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
