### PR TITLE
Chore: #102 데이터 100건 저장시 flush 처리

### DIFF
--- a/src/main/java/com/sparta/parknav/_global/data/MakeData.java
+++ b/src/main/java/com/sparta/parknav/_global/data/MakeData.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -157,9 +158,10 @@ public class MakeData {
         List<ParkOperInfo> parkOperInfoList = parkOperInfoRepository.findAllByParkInfoIdBetween(firstParkInfoId, lastParkInfoId);
         // 유저 정보 미리 로딩
         List<User> userList = userRepository.findAllByIdBetween(51L, 100L);
+        // 쿼리문 줄이기 위한 List 생성
+        List<ParkMgtInfo> mgtInfoList = new ArrayList<>();
 
         int idx = 0;
-        int cnt = 0;
         for (ParkInfo parkInfo : parkInfoList) {
 
             ParkOperInfo parkOperInfo = parkOperInfoList.get(idx++);
@@ -182,13 +184,11 @@ public class MakeData {
                 int charge = ParkingFeeCalculator.calculateParkingFee(Duration.between(startTime, endTime).toMinutes(), parkOperInfo);
 
                 ParkMgtInfo mgtInfo = ParkMgtInfo.of(parkInfo, car.getCarNum(), startTime, endTime, charge, null);
-                parkMgtInfoRepository.save(mgtInfo);
-
-                if (cnt++ % 100 == 0) {
-                    parkMgtInfoRepository.flush();
-                }
+                mgtInfoList.add(mgtInfo);
             }
         }
+        parkMgtInfoRepository.saveAll(mgtInfoList);
+
         return ResponseUtils.ok(MsgType.DATA_SUCCESSFULLY);
     }
 
@@ -201,9 +201,10 @@ public class MakeData {
         List<ParkOperInfo> parkOperInfoList = parkOperInfoRepository.findAllByParkInfoIdBetween(firstParkInfoId, lastParkInfoId);
         // 유저 정보 미리 로딩
         List<User> userList = userRepository.findAllByIdBetween(1L, 40L);
+        // 쿼리문 줄이기 위한 List 생성
+        List<ParkMgtInfo> mgtInfoList = new ArrayList<>();
 
         int idx = 0;
-        int cnt = 0;
         for (ParkInfo parkInfo : parkInfoList) {
 
             ParkOperInfo parkOperInfo = parkOperInfoList.get(idx++);
@@ -228,14 +229,11 @@ public class MakeData {
 
                 // 예약정보 포함하여 저장
                 ParkMgtInfo mgtInfo = ParkMgtInfo.of(parkInfo, car.getCarNum(), enterTime, exitTime, charge, bookingInfo);
-                parkMgtInfoRepository.save(mgtInfo);
-
-                if (cnt++ % 100 == 0) {
-                    parkMgtInfoRepository.flush();
-                }
+                mgtInfoList.add(mgtInfo);
             }
-
         }
+        parkMgtInfoRepository.saveAll(mgtInfoList);
+
         return ResponseUtils.ok(MsgType.DATA_SUCCESSFULLY);
     }
 

--- a/src/main/java/com/sparta/parknav/_global/data/MakeData.java
+++ b/src/main/java/com/sparta/parknav/_global/data/MakeData.java
@@ -117,8 +117,8 @@ public class MakeData {
         // 유저 정보 미리 로딩
         List<User> userList = userRepository.findAllByIdBetween(1L, 50L);
 
+        int cnt = 0;
         for (ParkInfo parkInfo : parkInfoList) {
-
             // 주차장별 50개 랜덤 데이터 만들기
             for (User user : userList) {
                 // 예약 시작시간 랜덤 설정
@@ -138,6 +138,10 @@ public class MakeData {
                 // ParkBookingInfo 만들어서 저장
                 ParkBookingInfo parkBookingInfo = ParkBookingInfo.of(startTime, endTime, user, parkInfo, car.getCarNum());
                 parkBookingInfoRepository.save(parkBookingInfo);
+
+                if (cnt++ % 100 == 0) {
+                    parkBookingInfoRepository.flush();
+                }
             }
         }
         return ResponseUtils.ok(MsgType.DATA_SUCCESSFULLY);
@@ -155,6 +159,7 @@ public class MakeData {
         List<User> userList = userRepository.findAllByIdBetween(51L, 100L);
 
         int idx = 0;
+        int cnt = 0;
         for (ParkInfo parkInfo : parkInfoList) {
 
             ParkOperInfo parkOperInfo = parkOperInfoList.get(idx++);
@@ -178,6 +183,10 @@ public class MakeData {
 
                 ParkMgtInfo mgtInfo = ParkMgtInfo.of(parkInfo, car.getCarNum(), startTime, endTime, charge, null);
                 parkMgtInfoRepository.save(mgtInfo);
+
+                if (cnt++ % 100 == 0) {
+                    parkMgtInfoRepository.flush();
+                }
             }
         }
         return ResponseUtils.ok(MsgType.DATA_SUCCESSFULLY);
@@ -194,6 +203,7 @@ public class MakeData {
         List<User> userList = userRepository.findAllByIdBetween(1L, 40L);
 
         int idx = 0;
+        int cnt = 0;
         for (ParkInfo parkInfo : parkInfoList) {
 
             ParkOperInfo parkOperInfo = parkOperInfoList.get(idx++);
@@ -219,6 +229,10 @@ public class MakeData {
                 // 예약정보 포함하여 저장
                 ParkMgtInfo mgtInfo = ParkMgtInfo.of(parkInfo, car.getCarNum(), enterTime, exitTime, charge, bookingInfo);
                 parkMgtInfoRepository.save(mgtInfo);
+
+                if (cnt++ % 100 == 0) {
+                    parkMgtInfoRepository.flush();
+                }
             }
 
         }


### PR DESCRIPTION
## 📕  데이터 100건 저장시 flush 처리

## 📗 작업 내용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 기타 수정

### 반영 브랜치
#102-flush -> develop

### 변경 사항
- 데이터 생성 및 저장 속도 향상을 위해 100건 저장시 flush 처리
- 데이터 생성 및 저장시 쿼리문을 최소화하기 위해 List<ParkMgtInfo>에 객체를 저장하고 한번에 saveAll 처리

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
