### PR TITLE
feat : #128 주차장 검색 검색결과 유사도 판별 기능 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
-
+    //텍스트 유사도 검증
+    implementation 'org.apache.commons:commons-text:1.9'
     //redis 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/parknav/parking/repository/ParkInfoRepository.java
+++ b/src/main/java/com/sparta/parknav/parking/repository/ParkInfoRepository.java
@@ -19,5 +19,7 @@ public interface ParkInfoRepository extends JpaRepository<ParkInfo,Long> {
 
     List<ParkInfo> findAllByIdBetween(Long firstParkInfoId, Long lastParkInfoId);
 
+    List<ParkInfo> findByNameContains(String keyword);
+
 }
 

--- a/src/main/java/com/sparta/parknav/parking/service/ParkSearchService.java
+++ b/src/main/java/com/sparta/parknav/parking/service/ParkSearchService.java
@@ -1,15 +1,14 @@
 package com.sparta.parknav.parking.service;
 
 import com.sparta.parknav._global.data.KakaoMapService;
-import com.sparta.parknav._global.response.ApiResponseDto;
-import com.sparta.parknav._global.response.MsgType;
-import com.sparta.parknav._global.response.ResponseUtils;
 import com.sparta.parknav.management.service.ParkingFeeCalculator;
 import com.sparta.parknav.parking.dto.*;
+import com.sparta.parknav.parking.entity.ParkInfo;
 import com.sparta.parknav.parking.entity.ParkOperInfo;
 import com.sparta.parknav.parking.entity.ParkType;
 import com.sparta.parknav.parking.repository.ParkInfoRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -23,7 +22,9 @@ public class ParkSearchService {
     private final ParkInfoRepository parkInfoRepository;
 
     public ParkSearchResponseDto searchPark(ParkSearchRequestDto parkSearchRequestDto) {
-        String lo, la, placeName;
+        String lo = null, la = null, placeName = null;
+        int similarScore = 100;
+        int searchSimilarScore = 100;
         List<ParkOperInfoDto> parkOperInfoDtos = new ArrayList<>();
         ParkSearchResponseDto parkSearchResponseDto = null;
 
@@ -31,23 +32,40 @@ public class ParkSearchService {
         if (parkSearchRequestDto.getKeyword() != null) {
             //카카오 검색 API호출
             KakaoSearchDto kakaoSearchDto = kakaoMapService.getKakaoSearch(parkSearchRequestDto.getKeyword());
-            //결과가 없을경우 리턴
-            if (kakaoSearchDto.getMeta().getTotal_count() == 0) {
-                return parkSearchResponseDto;
-            }
-            List<KakaoSearchDocumentsDto> kakaoSearchDocumentsDto = kakaoSearchDto.getDocuments();
-            lo = kakaoSearchDocumentsDto.get(0).getX();
-            la = kakaoSearchDocumentsDto.get(0).getY();
-            placeName = kakaoSearchDocumentsDto.get(0).getPlace_name();
-            for (KakaoSearchDocumentsDto kakao : kakaoSearchDocumentsDto) {
-                if (kakao.getPlace_name().equals(parkSearchRequestDto.getKeyword())) {
-                    lo = kakao.getX();
-                    la = kakao.getY();
-                    placeName = kakao.getPlace_name();
-                    break;
+            if (kakaoSearchDto.getMeta().getTotal_count() > 0) {
+                List<KakaoSearchDocumentsDto> kakaoSearchDocumentsDto = kakaoSearchDto.getDocuments();
+                lo = kakaoSearchDocumentsDto.get(0).getX();
+                la = kakaoSearchDocumentsDto.get(0).getY();
+                placeName = kakaoSearchDocumentsDto.get(0).getPlace_name();
+                // 0번 결과로 유사도 초기화
+                similarScore = similarKeyword(parkSearchRequestDto.getKeyword(), kakaoSearchDocumentsDto.get(0).getPlace_name());
+                for (KakaoSearchDocumentsDto kakao : kakaoSearchDocumentsDto) {
+                    // 검색결과 별 유사도 비교
+                    searchSimilarScore = similarKeyword(parkSearchRequestDto.getKeyword(), kakao.getPlace_name());
+                    if (searchSimilarScore < similarScore) {
+                        lo = kakao.getX();
+                        la = kakao.getY();
+                        placeName = kakao.getPlace_name();
+                        similarScore = searchSimilarScore;
+                    }
                 }
             }
-
+            // DB에서 Like검색
+            List<ParkInfo> parkInfos = parkInfoRepository.findByNameContains(parkSearchRequestDto.getKeyword());
+            for (ParkInfo parkInfo : parkInfos) {
+                // 검색결과 별 유사도 비교
+                searchSimilarScore = similarKeyword(parkSearchRequestDto.getKeyword(), parkInfo.getName());
+                if (searchSimilarScore < similarScore) {
+                    la = parkInfo.getLa();
+                    lo = parkInfo.getLo();
+                    placeName = parkInfo.getName();
+                    similarScore = searchSimilarScore;
+                }
+            }
+            //결과가 없을경우 리턴
+            if (placeName == null) {
+                return parkSearchResponseDto;
+            }
         } else {
             lo = parkSearchRequestDto.getLo();
             la = parkSearchRequestDto.getLa();
@@ -63,12 +81,16 @@ public class ParkSearchService {
             result = parkInfoRepository.findParkInfoWithOperInfoAndType(lo, la, 3000, ParkType.fromValue(parkSearchRequestDto.getType()));
         }
 
-        for (ParkOperInfo park:result){
-            ParkOperInfoDto parkOperInfoDto = ParkOperInfoDto.of(park, ParkingFeeCalculator.calculateParkingFee(parkSearchRequestDto.getParktime()* 60L,park));
+        for (ParkOperInfo park : result) {
+            ParkOperInfoDto parkOperInfoDto = ParkOperInfoDto.of(park, ParkingFeeCalculator.calculateParkingFee(parkSearchRequestDto.getParktime() * 60L, park));
             if (parkOperInfoDto.getTotCharge() <= parkSearchRequestDto.getCharge()) {
                 parkOperInfoDtos.add(parkOperInfoDto);
             }
         }
         return ParkSearchResponseDto.of(la, lo, placeName, parkOperInfoDtos);
+    }
+
+    public static int similarKeyword(String userKeyword, String keyword) {
+        return LevenshteinDistance.getDefaultInstance().apply(userKeyword, keyword);
     }
 }


### PR DESCRIPTION

## 📕 주차장 검색 검색결과 유사도 판별 기능 적용

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#128-search-similar-> develop

### 변경 사항
- 사용자 검색 시 검색 리스트에 DB 주차장 목록도 포함 ( 기존은 API만 )
- 주차장 검색 검색결과 유사도 판별 기능 적용

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
