### PR TITLE
Fix: #130 기존 예약, 입차 알고리즘 수정사항 적용

### DIFF
--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingInfoRepository.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingInfoRepository.java
@@ -23,4 +23,6 @@ public interface ParkBookingInfoRepository extends JpaRepository<ParkBookingInfo
     List<ParkBookingInfo> getSelectedTimeBookingList(@Param("parkId") Long parkId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
     List<ParkBookingInfo> findAllByParkInfoIdAndUserId(Long parkInfoId, Long userId);
+
+    List<ParkBookingInfo> findAllByParkInfoIdAndUserIdAndCarNum(Long parkInfoId, Long userId, String carNum);
 }

--- a/src/main/java/com/sparta/parknav/booking/service/BookingService.java
+++ b/src/main/java/com/sparta/parknav/booking/service/BookingService.java
@@ -98,7 +98,7 @@ public class BookingService {
                 () -> new CustomException(ErrorType.NOT_FOUND_CAR)
         ); // 2~5 , 1~3
         // SCENARIO BOOKING 4
-        List<ParkBookingInfo> parkBookingInfo = parkBookingInfoRepository.findAllByParkInfoIdAndUserId(parkInfo.getId(), user.getId());
+        List<ParkBookingInfo> parkBookingInfo = parkBookingInfoRepository.findAllByParkInfoIdAndUserIdAndCarNum(parkInfo.getId(), user.getId(), car.getCarNum());
         for (ParkBookingInfo p : parkBookingInfo) {
             if (p != null) {
                 if (requestDto.getStartDate().isBefore(p.getEndTime())&&requestDto.getEndDate().isAfter(p.getStartTime())) {
@@ -150,8 +150,8 @@ public class BookingService {
                 status = now.isBefore(p.getEndTime()) ? StatusType.UNUSED : StatusType.EXPIRED;
             }
 
-            // 예약내역으로 주차 출차까지 한 경우, 요금계산을 위해 실제 사용시간을 구한다.
-            if (parkMgtInfo.isPresent() && parkMgtInfo.get().getExitTime() != null) {
+            // 예약시간보다 오래 주차하고 출차한 경우, 요금계산을 위해 실제 사용시간을 구한다. 예약시간 이전에 출차했다면 예약한 시간만큼 요금을 받는다.
+            if (parkMgtInfo.isPresent() && parkMgtInfo.get().getExitTime() != null && parkMgtInfo.get().getExitTime().isAfter(p.getEndTime())) {
                 minutes = Duration.between(parkMgtInfo.get().getEnterTime(), parkMgtInfo.get().getExitTime()).toMinutes();
             }
 

--- a/src/main/java/com/sparta/parknav/management/repository/ParkMgtInfoRepository.java
+++ b/src/main/java/com/sparta/parknav/management/repository/ParkMgtInfoRepository.java
@@ -25,4 +25,6 @@ public interface ParkMgtInfoRepository extends JpaRepository<ParkMgtInfo,Long> {
     Optional<ParkMgtInfo> findByParkBookingInfoId(Long id);
 
     int countByParkBookingInfoIn(List<ParkBookingInfo> bookingInfoList);
+
+    Boolean existsByParkBookingInfoIdAndExitTimeIsNotNull(Long bookingInfoId);
 }

--- a/src/main/java/com/sparta/parknav/management/service/MgtService.java
+++ b/src/main/java/com/sparta/parknav/management/service/MgtService.java
@@ -78,6 +78,11 @@ public class MgtService {
             int bookingNowCnt = getBookingNowCnt(requestDto.getCarNum(), parkBookingInfo, now, parkMgtInfo);
             // 예약된 차량 찾기
             ParkBookingInfo parkBookingNow = getParkBookingInfo(requestDto, parkBookingInfo, now);
+            // 이미 예약내역으로 입차, 출차를 마친 경우는 예약시간 내 입차해도 일반차량으로 분류된다.
+            // SCENARIO ENTER 6
+            if (parkBookingNow != null && parkMgtInfoRepository.existsByParkBookingInfoIdAndExitTimeIsNotNull(parkBookingNow.getId())) {
+                parkBookingNow = null;
+            }
             // 주차 구획수
             int cmprtCoNum = parkInfo.getParkOperInfo().getCmprtCo();
             // 이 주차장에 현재 입차되어있는 차량 수


### PR DESCRIPTION
## 📕 기존 예약, 입차 알고리즘 수정사항 적용

## 📗 작업 내용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 기능 수정
- [x] 코드 리팩토링

### 반영 브랜치
fix/#130-booking-enter -> develop

### 변경 사항
- 나의 예약 현황 조회 주차요금 표시할 때, 예약시간 이전에 출차할 경우 요금은 예약시간 기준으로 계산하고, 예약시간 이후 출차할 경우 요금은 사용시간 기준으로 계산한다.
- 주차예약시, 기존 예약여부 확인할 때 주차장, 사용자로만 예약정보를 찾던 기존 로직에서 차량번호도 추가하여 해당 차량으로 예약한 정보가 있는지 확인한다.
- 예약한 차량이 주차장을 이용하고(입차, 출차 모두 완료) 예약 시간 내 다시 주차장에 들어올 경우, 입차정보에 예약ID는 null 처리하여 일반차량으로 입차되도록 한다.(입차 시나리오 6번 추가)
- 입차 테스트시 레디스 적용부분은 주석처리하고 진행했다.

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
