### PR TITLE
Feat: #132 주차장 조회시 현재 주차가능 대수 리턴

### DIFF
--- a/src/main/java/com/sparta/parknav/booking/service/OperationChecking.java
+++ b/src/main/java/com/sparta/parknav/booking/service/OperationChecking.java
@@ -1,0 +1,59 @@
+package com.sparta.parknav.booking.service;
+
+import com.sparta.parknav.parking.entity.ParkOperInfo;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class OperationChecking {
+
+    private LocalTime openTime;
+    private LocalTime closeTime;
+
+    @Builder
+    private OperationChecking(LocalTime openTime, LocalTime closeTime) {
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+    }
+
+    public static OperationChecking of(LocalTime openTime, LocalTime closeTime) {
+        return builder()
+                .openTime(openTime)
+                .closeTime(closeTime)
+                .build();
+    }
+
+    public static boolean checkOperation(LocalDateTime selectedTime, ParkOperInfo parkOperInfo) {
+
+        OperationChecking operation = OperationChecking.of(null, null);
+
+        // selectedTime 의 요일에 따른 운영시간 체크
+        switch(selectedTime.getDayOfWeek()) {
+            case SATURDAY -> {
+                operation.openTime = LocalTime.parse(parkOperInfo.getSatOpen());
+                operation.closeTime = LocalTime.parse(parkOperInfo.getSatClose());
+            }
+            case SUNDAY -> {
+                operation.openTime = LocalTime.parse(parkOperInfo.getSunOpen());
+                operation.closeTime = LocalTime.parse(parkOperInfo.getSunClose());
+            }
+            default -> {
+                operation.openTime = LocalTime.parse(parkOperInfo.getWeekdayOpen());
+                operation.closeTime = LocalTime.parse(parkOperInfo.getWeekdayClose());
+            }
+        }
+
+        // 시작시간, 종료시간이 00:00시라면 해당일엔 운영하지 않음
+        if (operation.openTime.equals(LocalTime.of(0, 0)) && operation.closeTime.equals(LocalTime.of(0, 0))) {
+            return false;
+        }
+
+        // selectedTime 이 운영시작시간 전이거나 운영종료시간 후인 경우 -> 선택한 시간은 운영 안함
+        if (selectedTime.toLocalTime().isBefore(operation.openTime) || (!operation.closeTime.equals(LocalTime.of(0, 0)) && selectedTime.toLocalTime().isAfter(operation.closeTime))) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/sparta/parknav/parking/controller/ParkSearchController.java
+++ b/src/main/java/com/sparta/parknav/parking/controller/ParkSearchController.java
@@ -31,9 +31,10 @@ public class ParkSearchController {
     public String mypage(){
         return "mypage";
     }
+
     @ResponseBody
     @GetMapping("/api/parks")
-    public ApiResponseDto<ParkSearchResponseDto> serchPark(ParkSearchRequestDto parkSearchRequestDto){
+    public ApiResponseDto<ParkSearchResponseDto> searchPark(ParkSearchRequestDto parkSearchRequestDto){
 
         return ResponseUtils.ok(parkSearchService.searchPark(parkSearchRequestDto), MsgType.SEARCH_SUCCESSFULLY);
 

--- a/src/main/java/com/sparta/parknav/parking/dto/ParkOperInfoDto.java
+++ b/src/main/java/com/sparta/parknav/parking/dto/ParkOperInfoDto.java
@@ -25,9 +25,10 @@ public class ParkOperInfoDto {
     private String lo;
     private String name;
     private int totCharge;
+    private String available;
 
     @Builder
-    private ParkOperInfoDto(ParkOperInfo parkOperInfo, int totCharge) {
+    private ParkOperInfoDto(ParkOperInfo parkOperInfo, int totCharge, String available) {
         this.id = parkOperInfo.getParkInfo().getId();
         this.chargeAditUnitChrg =  parkOperInfo.getChargeAditUnitChrg();
         this.chargeAditUnitTime = parkOperInfo.getChargeAditUnitTime();
@@ -47,12 +48,14 @@ public class ParkOperInfoDto {
         this.lo = parkOperInfo.getParkInfo().getLo();
         this.name = parkOperInfo.getParkInfo().getName();
         this.totCharge = totCharge;
+        this.available = available;
     }
 
-    public static ParkOperInfoDto of(ParkOperInfo parkOperInfo, int totCharge){
+    public static ParkOperInfoDto of(ParkOperInfo parkOperInfo, int totCharge, String available){
         return ParkOperInfoDto.builder()
                 .parkOperInfo(parkOperInfo)
                 .totCharge(totCharge)
+                .available(available)
                 .build();
     }
 }


### PR DESCRIPTION
## 📕 주차장 조회시 현재 주차가능 대수 리턴

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#132-search-info -> develop

### 변경 사항
- 기존 BookingService 내에서 사용했던 현재 주차가능 대수 구하는 메서드를 전역에서 사용할 수 있도록 `OperationChecking` 클래스를 만들고, `checkingOperation` static method 생성
- 주차장 조회시 현재 주차 가능대수를 리턴하기 위해 `ParkOperInfoDto`에 `available` 변수 추가
- 현재 운영중이지 않은 경우 '현재 운영중이 아닙니다' 메시지 리턴
- 현재 운영중인 경우, 현재 주차 가능대수 리턴

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
