### PR TITLE
Feat: #155 구역을 나타낼 ZONE 필드 추가

### DIFF
--- a/src/main/java/com/sparta/parknav/management/entity/ParkMgtInfo.java
+++ b/src/main/java/com/sparta/parknav/management/entity/ParkMgtInfo.java
@@ -39,15 +39,19 @@ public class ParkMgtInfo {
     @Column(nullable = false)
     private String carNum;
 
+    @Column(length = 10)
+    @Enumerated(EnumType.STRING)
+    private ZoneType zone;
+
     @Builder
-    private ParkMgtInfo(ParkInfo parkInfo, String carNum, LocalDateTime enterTime
-            , LocalDateTime exitTime, int charge, ParkBookingInfo parkBookingInfo) {
+    private ParkMgtInfo(ParkInfo parkInfo, String carNum, LocalDateTime enterTime, LocalDateTime exitTime, int charge, ParkBookingInfo parkBookingInfo, ZoneType zone) {
         this.parkInfo = parkInfo;
         this.carNum = carNum;
         this.enterTime = enterTime;
         this.exitTime = exitTime;
         this.charge = charge;
         this.parkBookingInfo = parkBookingInfo;
+        this.zone = zone;
     }
 
     public static ParkMgtInfo of(ParkInfo parkInfo, String carNum, LocalDateTime enterTime

--- a/src/main/java/com/sparta/parknav/management/entity/ZoneType.java
+++ b/src/main/java/com/sparta/parknav/management/entity/ZoneType.java
@@ -1,0 +1,14 @@
+package com.sparta.parknav.management.entity;
+
+public enum ZoneType {
+    GENERAL("일반"),
+    BOOKING("예약"),
+    COMMON("공통");
+
+    private final String value;
+
+    ZoneType(String value) {
+        this.value = value;
+    }
+
+}


### PR DESCRIPTION
## 📕 구역을 나타낼 ZONE 필드 추가

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#155-version1-1 -> develop

### 변경 사항
- 공통, 예약, 일반 구역을 나누어 `ParkMgtInfo` 필드에 나타낸다.

### 테스트 결과
테이블 컬럼 생성 확인하였습니다.
