### PR TITLE
Feat: #157 주차장 검색 부분 FULLTEXT index 적용

### DIFF
--- a/src/main/java/com/sparta/parknav/parking/repository/ParkInfoRepository.java
+++ b/src/main/java/com/sparta/parknav/parking/repository/ParkInfoRepository.java
@@ -1,7 +1,6 @@
 package com.sparta.parknav.parking.repository;
 
 import com.sparta.parknav.parking.entity.ParkInfo;
-import com.sparta.parknav.parking.entity.ParkOperInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,7 +11,7 @@ public interface ParkInfoRepository extends JpaRepository<ParkInfo,Long>, ParkIn
 
     List<ParkInfo> findAllByIdBetween(Long firstParkInfoId, Long lastParkInfoId);
 
-    List<ParkInfo> findByNameContains(String keyword);
-
+    @Query(value = "SELECT * FROM park_info a WHERE MATCH(a.name) AGAINST(?1 IN BOOLEAN MODE)", nativeQuery = true)
+    List<ParkInfo> findAllParkInfoWithKeyword(@Param("matchKeyword") String matchKeyword);
 }
 

--- a/src/main/java/com/sparta/parknav/parking/service/ParkSearchService.java
+++ b/src/main/java/com/sparta/parknav/parking/service/ParkSearchService.java
@@ -20,7 +20,9 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,8 +61,14 @@ public class ParkSearchService {
                     }
                 }
             }
-            // DB에서 Like검색
-            List<ParkInfo> parkInfos = parkInfoRepository.findByNameContains(parkSearchRequestDto.getKeyword());
+
+            // DB에서 검색
+            String[] keywords = parkSearchRequestDto.getKeyword().split(" ");
+            String matchKeyword = Arrays.stream(keywords)
+                    .map(k -> "+" + k + " ")
+                    .collect(Collectors.joining());
+            
+            List<ParkInfo> parkInfos = parkInfoRepository.findAllParkInfoWithKeyword(matchKeyword);
             for (ParkInfo parkInfo : parkInfos) {
                 // 검색결과 별 유사도 비교
                 searchSimilarScore = similarKeyword(parkSearchRequestDto.getKeyword(), parkInfo.getName());


### PR DESCRIPTION
## 📕 주차장 검색 부분 FULLTEXT index 적용

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#157-search -> develop

### 변경 사항
- 키워드 검색시 DB에서 주차장 정보를 찾을 때 FULLTEXT index가 적용되도록 구현
- 두 단어 이상 검색할 경우, 각 단어 앞에 '+'를 붙이도록 키워드 수정 후 검색 쿼리 실행
- native query 사용하여 FULLTEXT index 적용한 상태로 쿼리 실행되도록 구현

### 테스트 결과
의도한 결과대로 주차장 검색결과가 나옵니다.
