### PR TITLE
Feat: #152 출차 v2 구현

### DIFF
--- a/src/main/java/com/sparta/parknav/_global/exception/ErrorType.java
+++ b/src/main/java/com/sparta/parknav/_global/exception/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
     NOT_AVAILABLE_TIME(400, "예약 시작 시간은 현재 시간 이전일 수 없습니다."),
     NOT_END_TO_START(400,"입차시간이 출차시간보다 빨라야 합니다."),
     NOT_FOUND_CAR(400, "등록된 차량이 없습니다."),
+    NOT_FOUND_CAR_IN_PARK(400, "주차장에 차량이 없습니다."),
     NOT_FOUND_BOOKING(400, "예약 내역이 존재하지 않습니다."),
     NOT_BOOKING_USER(400, "본인이 예약한 내역이 아닙니다."),
     NOT_MGT_USER(400, "해당 주차장의 관리자가 아닙니다."),

--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepository.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepository.java
@@ -4,11 +4,8 @@ import com.sparta.parknav.booking.entity.ParkBookingByHour;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public interface ParkBookingByHourRepository extends JpaRepository<ParkBookingByHour, Long> {
 
     ParkBookingByHour findByParkInfoIdAndDateAndTime(Long parkInfoId, LocalDate startDate, int time);
-
-    List<ParkBookingByHour> findByParkInfoIdAndDateAndTimeBetween(Long parkInfoId, LocalDate date, int exitTime, int endTime);
 }

--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepository.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepository.java
@@ -5,9 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface ParkBookingByHourRepository extends JpaRepository<ParkBookingByHour, Long> {
 
     ParkBookingByHour findByParkInfoIdAndDateAndTime(Long parkInfoId, LocalDate startDate, int time);
+
+    List<ParkBookingByHour> findByParkInfoIdAndDateAndTimeBetween(Long parkInfoId, LocalDate date, int exitTime, int endTime);
 }

--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryCustom.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.sparta.parknav.booking.repository;
+
+import com.sparta.parknav.booking.entity.ParkBookingByHour;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ParkBookingByHourRepositoryCustom {
+    List<ParkBookingByHour> findByParkInfoIdAndFromStartDateToEndDate(Long parkInfoId, LocalDateTime startDate, LocalDateTime endDate);
+}

--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryImpl.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryImpl.java
@@ -1,0 +1,79 @@
+package com.sparta.parknav.booking.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.parknav.booking.entity.ParkBookingByHour;
+import com.sparta.parknav.booking.entity.QParkBookingByHour;
+import com.sparta.parknav.parking.entity.QParkInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ParkBookingByHourRepositoryImpl implements ParkBookingByHourRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QParkBookingByHour qParkBookingByHour = QParkBookingByHour.parkBookingByHour;
+    private final QParkInfo qParkInfo = QParkInfo.parkInfo;
+
+    @Override
+    public List<ParkBookingByHour> findByParkInfoIdAndFromStartDateToEndDate(Long parkInfoId, LocalDateTime startDate, LocalDateTime endDate) {
+
+        LocalDate startDay = startDate.toLocalDate();
+        LocalDate endDay = endDate.toLocalDate();
+        long days = Period.between(startDay, endDay).getDays();
+        int startTime = startDate.getHour();
+        int endTime = endDate.getHour();
+
+        log.info("days = " + days);
+
+        List<ParkBookingByHour> result = new ArrayList<>();
+        if (days == 0) {
+            result = jpaQueryFactory.selectFrom(qParkBookingByHour)
+                    .innerJoin(qParkBookingByHour.parkInfo, qParkInfo)
+                    .fetchJoin()
+                    .where(qParkBookingByHour.parkInfo.id.eq(parkInfoId)
+                            .and(qParkBookingByHour.date.eq(startDay))
+                            .and(qParkBookingByHour.time.between(startTime, endTime)))
+                    .fetch();
+        } else {
+            List<ParkBookingByHour> resultFirstDay = jpaQueryFactory.selectFrom(qParkBookingByHour)
+                    .innerJoin(qParkBookingByHour.parkInfo, qParkInfo)
+                    .fetchJoin()
+                    .where(qParkBookingByHour.parkInfo.id.eq(parkInfoId)
+                            .and(qParkBookingByHour.date.eq(startDay))
+                            .and(qParkBookingByHour.time.between(startTime, 23)))
+                    .fetch();
+
+            List<ParkBookingByHour> resultLastDay = jpaQueryFactory.selectFrom(qParkBookingByHour)
+                    .innerJoin(qParkBookingByHour.parkInfo, qParkInfo)
+                    .fetchJoin()
+                    .where(qParkBookingByHour.parkInfo.id.eq(parkInfoId)
+                            .and(qParkBookingByHour.date.eq(endDay))
+                            .and(qParkBookingByHour.time.between(0, endTime)))
+                    .fetch();
+
+            result.addAll(resultFirstDay);
+            result.addAll(resultLastDay);
+
+            if (days > 1) {
+                List<ParkBookingByHour> resultMiddleDays = jpaQueryFactory.selectFrom(qParkBookingByHour)
+                        .innerJoin(qParkBookingByHour.parkInfo, qParkInfo)
+                        .fetchJoin()
+                        .where(qParkBookingByHour.parkInfo.id.eq(parkInfoId)
+                                .and(qParkBookingByHour.date.between(startDay.plusDays(1), endDay.minusDays(1))))
+                        .fetch();
+                result.addAll(resultMiddleDays);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryImpl.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryImpl.java
@@ -32,8 +32,6 @@ public class ParkBookingByHourRepositoryImpl implements ParkBookingByHourReposit
         int startTime = startDate.getHour();
         int endTime = endDate.getHour();
 
-        log.info("days = " + days);
-
         List<ParkBookingByHour> result = new ArrayList<>();
         if (days == 0) {
             result = jpaQueryFactory.selectFrom(qParkBookingByHour)

--- a/src/main/java/com/sparta/parknav/booking/service/BookingService.java
+++ b/src/main/java/com/sparta/parknav/booking/service/BookingService.java
@@ -220,12 +220,12 @@ public class BookingService {
     public void parkBookingByHourSave(Long id, ParkOperInfo parkOperInfo, LocalDateTime startDate, LocalDateTime endDate) {
 
         List<ParkBookingByHour> parkBookingByHourList = new ArrayList<>();
-        // 시간차이를 구한다
-        int startTime = startDate.getHour();
-        int endTime = endDate.getMinute() != 0 ? endDate.getHour() + 1 : endDate.getHour();
-        long hours = endTime - startTime;
-        // 시작시간을 구한다
-        // 총 시간만큼 For문을 순회한다
+
+        long hours = Duration.between(startDate, endDate).toHours();
+        if (endDate.getMinute() != 0 || endDate.getSecond() != 0) {
+            hours++;
+        }
+
         for (int i = 0; i < hours; i++) {
             LocalDateTime time = startDate.plusHours(i);
             // 기존에 저장 된 ParkBookingByHour가 있으면 available -1 없을경우 새로 저장한다

--- a/src/main/java/com/sparta/parknav/management/repository/ParkMgtInfoRepository.java
+++ b/src/main/java/com/sparta/parknav/management/repository/ParkMgtInfoRepository.java
@@ -20,7 +20,7 @@ public interface ParkMgtInfoRepository extends JpaRepository<ParkMgtInfo,Long> {
 
     int countByParkInfoIdAndExitTimeIsNull(Long id);
 
-    Optional<ParkMgtInfo> findTopByParkInfoIdAndCarNumOrderByEnterTimeDesc(Long parkId, String carNum);
+    Optional<ParkMgtInfo> findTopByParkInfoIdAndCarNumAndExitTimeNullOrderByEnterTimeDesc(Long parkId, String carNum);
 
     Optional<ParkMgtInfo> findByParkBookingInfoId(Long id);
 

--- a/src/main/java/com/sparta/parknav/management/service/MgtService.java
+++ b/src/main/java/com/sparta/parknav/management/service/MgtService.java
@@ -156,7 +156,7 @@ public class MgtService {
         ParkBookingInfo bookingInfo = parkMgtInfo.getParkBookingInfo();
         long minutes = Duration.between(bookingInfo.getStartTime(), now).toMinutes();
 
-        if (bookingInfo.getUser() != null && bookingInfo.getEndTime().isAfter(now)) {
+        if (bookingInfo.getUser() != null) {
             minutes = Duration.between(bookingInfo.getStartTime(), bookingInfo.getEndTime()).toMinutes();
         }
 

--- a/src/main/java/com/sparta/parknav/management/service/MgtService.java
+++ b/src/main/java/com/sparta/parknav/management/service/MgtService.java
@@ -5,6 +5,7 @@ import com.sparta.parknav._global.exception.ErrorType;
 import com.sparta.parknav.booking.entity.ParkBookingByHour;
 import com.sparta.parknav.booking.entity.ParkBookingInfo;
 import com.sparta.parknav.booking.repository.ParkBookingByHourRepository;
+import com.sparta.parknav.booking.repository.ParkBookingByHourRepositoryCustom;
 import com.sparta.parknav.booking.repository.ParkBookingInfoRepository;
 import com.sparta.parknav.booking.service.BookingService;
 import com.sparta.parknav.management.dto.request.CarNumRequestDto;
@@ -45,6 +46,7 @@ public class MgtService {
     private final ParkMgtInfoRepository parkMgtInfoRepository;
     private final ParkBookingByHourRepository parkBookingByHourRepository;
     private final ParkOperInfoRepository parkOperInfoRepository;
+    private final ParkBookingByHourRepositoryCustom parkBookingByHourRepositoryCustom;
 
     private final BookingService bookingService;
 
@@ -163,9 +165,7 @@ public class MgtService {
         int charge = ParkingFeeCalculator.calculateParkingFee(minutes, parkOperInfo);
 
         // SCENARIO EXIT 5
-        int endHour = (bookingInfo.getEndTime().getMinute() == 0 && bookingInfo.getEndTime().getSecond() == 0) ? bookingInfo.getEndTime().getHour() - 1 : bookingInfo.getEndTime().getHour();
-        List<ParkBookingByHour> hourList = parkBookingByHourRepository
-                .findByParkInfoIdAndDateAndTimeBetween(parkOperInfo.getParkInfo().getId(), now.toLocalDate(), now.getHour(), endHour);
+        List<ParkBookingByHour> hourList = parkBookingByHourRepositoryCustom.findByParkInfoIdAndFromStartDateToEndDate(parkOperInfo.getParkInfo().getId(), now, bookingInfo.getEndTime());
         hourList.forEach(hour -> hour.updateCnt(1));
 
         parkMgtInfo.update(charge, now);


### PR DESCRIPTION
## 📕 출차 v2 구현

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#152-v2-exit -> version2

### 변경 사항
- 즉시예약, 사전예약 & 예약종료 전 출차하는 경우, 사전예약 & 예약종료 후 출차하는 경우 나누어 요금 계산 구현
- 출차시, 기존 시간별 예약현황에서 출차 후 시간대의 주차가능대수를 한 자리씩 늘리도록 구현

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
