### PR TITLE
fix : v2 출차시 예약 종료시간을 현재 시간으로 변경

### DIFF
--- a/src/main/java/com/sparta/parknav/booking/entity/ParkBookingInfo.java
+++ b/src/main/java/com/sparta/parknav/booking/entity/ParkBookingInfo.java
@@ -79,6 +79,9 @@ public class ParkBookingInfo {
     public void startTimeUpdate(LocalDateTime dateTime) {
         this.startTime = dateTime;
     }
+    public void endTimeUpdate(LocalDateTime dateTime) {
+        this.endTime = dateTime;
+    }
 
     public void endTimePlus(int hour) {
         this.endTime = this.endTime.plusHours(hour);

--- a/src/main/java/com/sparta/parknav/management/service/MgtService.java
+++ b/src/main/java/com/sparta/parknav/management/service/MgtService.java
@@ -189,6 +189,9 @@ public class MgtService {
         List<ParkBookingByHour> hourList = parkBookingByHourRepositoryCustom.findByParkInfoIdAndFromStartDateToEndDate(parkOperInfo.getParkInfo().getId(), now, bookingInfo.getEndTime());
         hourList.forEach(hour -> hour.updateCnt(1));
 
+        // SCENARIO EXIT 6
+        bookingInfo.endTimeUpdate(now);
+
         parkMgtInfo.update(charge, now);
 
         return CarOutResponseDto.of(charge, now);


### PR DESCRIPTION
## 📕 출차시 예약 종료시간을 현재 시간으로 변경

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/v2/exit -> version2

### 변경 사항
- 출차시 예약 종료시간을 현재 시간으로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
