### PR TITLE
Feat: #152 예약 취소시 주차가능대수 업데이트

### DIFF
--- a/src/main/java/com/sparta/parknav/booking/service/BookingService.java
+++ b/src/main/java/com/sparta/parknav/booking/service/BookingService.java
@@ -12,6 +12,7 @@ import com.sparta.parknav.booking.entity.ParkBookingInfo;
 import com.sparta.parknav.booking.entity.StatusType;
 import com.sparta.parknav.booking.repository.CarRepository;
 import com.sparta.parknav.booking.repository.ParkBookingByHourRepository;
+import com.sparta.parknav.booking.repository.ParkBookingByHourRepositoryCustom;
 import com.sparta.parknav.booking.repository.ParkBookingInfoRepository;
 import com.sparta.parknav.management.entity.ParkMgtInfo;
 import com.sparta.parknav.management.repository.ParkMgtInfoRepository;
@@ -49,6 +50,7 @@ public class BookingService {
     private final ParkInfoRepository parkInfoRepository;
     private final CarRepository carRepository;
     private final ParkBookingByHourRepository parkBookingByHourRepository;
+    private final ParkBookingByHourRepositoryCustom parkBookingByHourRepositoryCustom;
 
     public BookingInfoResponseDto getInfoBeforeBooking(Long id, BookingInfoRequestDto requestDto) {
 
@@ -154,6 +156,9 @@ public class BookingService {
         if (!bookingInfo.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorType.NOT_BOOKING_USER);
         }
+
+        List<ParkBookingByHour> hourList = parkBookingByHourRepositoryCustom.findByParkInfoIdAndFromStartDateToEndDate(bookingInfo.getParkInfo().getId(), bookingInfo.getStartTime(), bookingInfo.getEndTime());
+        hourList.forEach(hour -> hour.updateCnt(1));
 
         parkBookingInfoRepository.deleteById(id);
     }


### PR DESCRIPTION
## 📕 예약 취소시 주차가능대수 업데이트

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
#152/feat-cancel -> develop

### 변경 사항
- 예약 취소시 ParkBookingByHour의 available을 1 늘리도록 구현

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
