### PR TITLE
feat : 예약 시작시간과 종료시간의 최대 차이는 1주일로 변경

### DIFF
--- a/src/main/java/com/sparta/parknav/_global/exception/ErrorType.java
+++ b/src/main/java/com/sparta/parknav/_global/exception/ErrorType.java
@@ -32,7 +32,9 @@ public enum ErrorType {
     NOT_PARKING_SPACE(400, "주차할 공간이 없습니다."),
     NOT_TOKEN(401, "토큰이 없습니다."),
     NOT_VALID_TOKEN(401, "토큰이 유효하지 않습니다."),
-    PARK_TIME_NOT_EXIST(400, "주차 예정 시간을 입력 해주세요.");
+    PARK_TIME_NOT_EXIST(400, "주차 예정 시간을 입력 해주세요."),
+    FORBIDDEN_TIME(400, "예약 시간은 일주일 이하만 가능합니다"),
+    ;
 
     private int code;
     private String msg;

--- a/src/main/java/com/sparta/parknav/booking/service/BookingService.java
+++ b/src/main/java/com/sparta/parknav/booking/service/BookingService.java
@@ -89,6 +89,11 @@ public class BookingService {
 
     public BookingResponseDto bookingLogic(Long parkId, BookingInfoRequestDto requestDto, User user) {
 
+        // 예약 시간 일주일 이상 차이날시 예외 발생
+        if (Duration.between(requestDto.getStartDate(), requestDto.getEndDate()).toDays() >= 7) {
+            throw new CustomException(ErrorType.FORBIDDEN_TIME);
+        }
+
         // SCENARIO BOOKING PRE 1
         if (!requestDto.getStartDate().isBefore(requestDto.getEndDate())) {
             throw new CustomException(ErrorType.NOT_END_TO_START);

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -56,14 +56,22 @@ $(document).ready(function () {
     $('#start-date').datepicker({
         format: 'yyyy-mm-dd',
         autoclose: true,
-        startDate: new Date()
+        startDate: new Date(),
+    }).on('changeDate', function (e) {
+        // start-date가 선택되었을 때
+        const startDate = e.date;
+        // 종료 날짜의 최소 날짜를 7일 후로 설정
+        const minEndDate = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + 7);
+        $('#exit-date').datepicker('setEndDate', minEndDate);
+        $('#exit-date').datepicker('setStartDate', startDate);
     });
 
     // 종료 날짜를 datepicker로 초기화
     $('#exit-date').datepicker({
         format: 'yyyy-mm-dd',
         autoclose: true,
-        startDate: new Date()
+        startDate: new Date(),
+        endDate: new Date(now.getTime() + (7 * 24 * 60 * 60 * 1000))
     });
 
     // 검색어 input에서 Enter 키 입력 시 이벤트
@@ -120,10 +128,13 @@ $(document).ready(function () {
         const endDateTime = endDate + "T" + endTime;
         const now = new Date();
         const startDateTimetoDate = new Date(startDateTime);
+        const endDateTimetoDate = new Date(endDateTime);
         // 년월일시까지만 비교할 현재 시간
         const nowTimeHours = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours());
-        // 년월일시까지만 비교할 사용자 입력 시간
-        const userStartDateTimeHours = new Date(startDateTimetoDate.getFullYear(), startDateTimetoDate.getMonth(), startDateTimetoDate.getDate(), startDateTimetoDate.getHours());
+        if (endDateTimetoDate.getTime()-startDateTimetoDate.getTime() > 604800000){
+            alert("일주일 이상 예약 할 수 없습니다");
+            return false;
+        }
 
         if (startDateTime >= endDateTime) {
             alert("종료 시간이 시작 시간보다 같거나 빠릅니다.");
@@ -133,6 +144,7 @@ $(document).ready(function () {
             alert("현재 시간 이후로만 선택 가능합니다")
             return false;
         }
+        console.log(startDateTimetoDate.getTime()-endDateTimetoDate.getTime());
         const body = {
             startDate: startDateTime,
             endDate: endDateTime,
@@ -180,6 +192,12 @@ $(document).ready(function () {
         const id = $("#parking-lot-id").val();
         const startDate = $('#start-date').val() + "T" + $('#start-time').val();
         const endDate = $('#exit-date').val() + "T" + $('#exit-time').val();
+        const startDateTimetoDate = new Date(startDate);
+        const endDateTimetoDate = new Date(endDate);
+        if (endDateTimetoDate.getTime()-startDateTimetoDate.getTime() > 604800000){
+            alert("일주일 이상 예약 할 수 없습니다");
+            return false;
+        }
         const body = {
             startDate: startDate,
             endDate: endDate


### PR DESCRIPTION
## 📕 예약 시작시간과 종료시간의 최대 차이는 1주일로 변경

## 📗 작업 내용

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#84-reserve-time-maximum-1week -> develop

### 변경 사항
- 예약시 예약 시작시간과 예약 종료시간의 차이가 1주일이 넘어가면 예외 발생

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
