### PR TITLE
Fix : #191 available 주차가능대수가 총 구획 수를 넘지 않도록 설정

### DIFF
--- a/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryImpl.java
+++ b/src/main/java/com/sparta/parknav/booking/repository/ParkBookingByHourRepositoryImpl.java
@@ -31,6 +31,9 @@ public class ParkBookingByHourRepositoryImpl implements ParkBookingByHourReposit
         long days = Period.between(startDay, endDay).getDays();
         int startTime = startDate.getHour();
         int endTime = endDate.getHour();
+        if (endDate.toLocalTime().getMinute() == 0 && endDate.toLocalTime().getSecond() == 0) {
+            endTime = endDate.minusHours(1).getHour();
+        }
 
         List<ParkBookingByHour> result = new ArrayList<>();
         if (days == 0) {

--- a/src/main/java/com/sparta/parknav/booking/service/BookingService.java
+++ b/src/main/java/com/sparta/parknav/booking/service/BookingService.java
@@ -180,7 +180,14 @@ public class BookingService {
         }
 
         List<ParkBookingByHour> hourList = parkBookingByHourRepositoryCustom.findByParkInfoIdAndFromStartDateToEndDate(bookingInfo.getParkInfo().getId(), bookingInfo.getStartTime(), bookingInfo.getEndTime());
-        hourList.forEach(hour -> hour.updateCnt(1));
+        ParkOperInfo parkOperInfo = parkOperInfoRepository.findByParkInfoId(bookingInfo.getParkInfo().getId()).orElseThrow(
+                () -> new CustomException(ErrorType.NOT_FOUND_PARK_OPER_INFO)
+        );
+        hourList.forEach(hour -> {
+            if (hour.getAvailable() < parkOperInfo.getCmprtCo()) {
+                hour.updateCnt(1);
+            }
+        });
 
         parkBookingInfoRepository.deleteById(id);
     }

--- a/src/main/java/com/sparta/parknav/management/service/MgtService.java
+++ b/src/main/java/com/sparta/parknav/management/service/MgtService.java
@@ -151,7 +151,11 @@ public class MgtService {
 
         // SCENARIO EXIT 5
         List<ParkBookingByHour> hourList = parkBookingByHourRepositoryCustom.findByParkInfoIdAndFromStartDateToEndDate(parkOperInfo.getParkInfo().getId(), now, bookingInfo.getEndTime());
-        hourList.forEach(hour -> hour.updateCnt(1));
+        hourList.forEach(hour -> {
+            if (hour.getAvailable() < parkOperInfo.getCmprtCo()) {
+                hour.updateCnt(1);
+            }
+        });
 
         // SCENARIO EXIT 6
         bookingInfo.endTimeUpdate(now);


### PR DESCRIPTION
## 📕 available 주차가능대수가 총 구획 수를 넘지 않도록 설정

## 📗 작업 내용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/#191-available-plus -> develop

### 변경 사항
- 출차 및 예약취소시 총 구획 수를 넘지 않는 경우에만 available 주차가능대수를 늘린다.
- endDate가 0분0초로 떨어질 경우에는 해당 시간대 바로 앞 시간까지만 ParkBookingByHour를 구한다.

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
