### PR TITLE
Fix : 스케쥴링시 예약 테이블의 예약 종료시간이 아니라 exitTime을 보고 park_booking_by_hour변경

### DIFF
--- a/src/main/java/com/sparta/parknav/_global/scheduler/SchedulerService.java
+++ b/src/main/java/com/sparta/parknav/_global/scheduler/SchedulerService.java
@@ -34,9 +34,7 @@ public class SchedulerService {
     @PreAuthorize("permitAll()")
     @Scheduled(cron = "0 * * * * *")
     public void scheduleRun() {
-        log.info("스케쥴링 시작");
         List<ParkMgtInfo> parkMgtInfos = parkMgtInfoRepository.findAllByExitTimeIsNullAndParkBookingInfoExitTimeBefore(LocalDateTime.now());
-        log.info("스케쥴링 중간");
         for (ParkMgtInfo p : parkMgtInfos) {
             ParkBookingInfo parkBookingInfo = p.getParkBookingInfo();
             if (parkBookingInfo == null) {
@@ -59,6 +57,5 @@ public class SchedulerService {
                 parkBookingByHourRepository.save(parkBookingByHour);
             }
         }
-        log.info("스케쥴링 종료");
     }
 }


### PR DESCRIPTION
## 📕 스케쥴링시 예약 테이블의 예약 종료시간이 아니라 exitTime을 보고 park_booking_by_hour변경

## 📗 작업 내용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/scheduler -> develop

### 변경 사항
- 스케쥴링시 예약 테이블의 예약 종료시간이 아니라 exitTime을 보고 park_booking_by_hour변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
