### PR TITLE
Fix : 정렬 디폴트를 예약 시작순으로 변경

### DIFF
--- a/src/main/java/com/sparta/parknav/management/service/MgtService.java
+++ b/src/main/java/com/sparta/parknav/management/service/MgtService.java
@@ -264,16 +264,16 @@ public class MgtService {
 
         switch (sort) {
             case 0:
-                Collections.sort(parkMgtResponseDtos, Comparator.comparing(ParkMgtResponseDto::getEnterTime, Comparator.nullsLast(Comparator.reverseOrder())));
-                break;
-            case 1:
-                Collections.sort(parkMgtResponseDtos, Comparator.comparing(ParkMgtResponseDto::getExitTime, Comparator.nullsLast(Comparator.reverseOrder())));
-                break;
-            case 2:
                 Collections.sort(parkMgtResponseDtos, Comparator.comparing(ParkMgtResponseDto::getBookingStartTime, Comparator.nullsLast(Comparator.reverseOrder())));
                 break;
-            case 3:
+            case 1:
                 Collections.sort(parkMgtResponseDtos, Comparator.comparing(ParkMgtResponseDto::getBookingEndTime, Comparator.nullsLast(Comparator.reverseOrder())));
+                break;
+            case 2:
+                Collections.sort(parkMgtResponseDtos, Comparator.comparing(ParkMgtResponseDto::getEnterTime, Comparator.nullsLast(Comparator.reverseOrder())));
+                break;
+            case 3:
+                Collections.sort(parkMgtResponseDtos, Comparator.comparing(ParkMgtResponseDto::getExitTime, Comparator.nullsLast(Comparator.reverseOrder())));
                 break;
             default:
                 break;

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -59,10 +59,10 @@
             </div>
             <div class="btn-group">
                 <select class="form-select me-2 btn btn-secondary dropdown-toggle" id ="sort-button" aria-label="정렬">
-                    <option value="0">입차시간순</option>
-                    <option value="1">출차시간순</option>
-                    <option value="2">예약시간순</option>
-                    <option value="3">예약종료순</option>
+                    <option value="0">예약시간순</option>
+                    <option value="1">예약종료순</option>
+                    <option value="2">입차시간순</option>
+                    <option value="3">출차시간순</option>
                 </select>
             </div>
             <table class="table table-striped table-hover text-center">


### PR DESCRIPTION
## 📕 정렬 디폴트를 예약 시작순으로 변경

## 📗 작업 내용

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feat/sort-charge -> develop

### 변경 사항
- 기존 입차순 정렬이 디폴트값 -> 예약순 정렬을 디폴트값으로 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.
